### PR TITLE
code coverage no longer includes spec files; remove version history from README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ rvm:
   - 2.4.1
   - 2.4.2
 
+# script, expressed as an array, is necessary for 'bundle exec coveralls push' to work locally
+script:
+  - bundle exec rake
+
 cache: bundler
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -104,16 +104,3 @@ pd.path
 pd.content_dir
 => "/purl/ab/123/cd/4567"
 ```
-
-### History
-
-- <b>0.3.0</b> - Added #prune method. Added AccessDruid for stacks and purl access
-- <b>0.2.6</b> - Fixed VERSION warning message, and documentation cleanup
-- <b>0.2.5</b> - Added glob pattern as DruidTools::Druid.glob
-- <b>0.2.4</b> - Allow non-String as .new parameter and added InvalidDruidError
-- <b>0.2.3</b> - Fine tune behavior of find_filelist_parent
-- <b>0.2.2</b> - Added find_filelist_parent method allowing search for a set of files
-- <b>0.2.1</b> - Do not error out during symlink creation if it already exists
-- <b>0.2.0</b> - Added DruidTools::Druid.valid?
-- <b>0.1.0</b> - Additional support for alternate content locations
-- <b>0.0.1</b> - Initial Release

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,13 @@
 #$LOAD_PATH.unshift(File.expand_path('../../lib',__FILE__))
 
+require 'coveralls'
+Coveralls.wear_merged! # because we run travis on multiple rubies
+
+require 'simplecov'
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter 'spec'
+end
+
 require 'bundler/setup'
 Bundler.require(:default, :development)
-
-require 'coveralls'
-Coveralls.wear!


### PR DESCRIPTION
coveralls was calculating coverage for at least one spec file;  this fixes it.  I started with an intended but benign change (get version history out of README);  ended with the actual fix.

Note that coverage decrease (which is small) is because we no longer include the spec files (duh).


