### PR TITLE
Allow ruby 2.7 usage of the gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
   Exclude:
     - 'Gemfile.lock'

--- a/druid-tools.gemspec
+++ b/druid-tools.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ['ALv2', 'Stanford University Libraries']
   gem.metadata['rubygems_mfa_required'] = 'true'
 
-  gem.required_ruby_version = '>= 3.0'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
## Why was this change made? 🤔

To allow DSA to use druid-tools gem releases.

## How was this change tested? 🤨

CI
